### PR TITLE
Update Maven to version 3.8.9

### DIFF
--- a/images/centos/toolsets/toolset-9.json
+++ b/images/centos/toolsets/toolset-9.json
@@ -71,7 +71,7 @@
     "java": {
         "default": "11",
         "versions": [ "11", "17", "21"],
-        "maven": "3.8.8"
+        "maven": "3.8.9"
     },
     "android": {
         "cmdline-tools": "commandlinetools-linux-9477386_latest.zip",

--- a/images/ubuntu/toolsets/toolset-2204.json
+++ b/images/ubuntu/toolsets/toolset-2204.json
@@ -71,7 +71,7 @@
     "java": {
         "default": "11",
         "versions": ["11", "17", "21"],
-        "maven": "3.8.8"
+        "maven": "3.8.9"
     },
     "android": {
         "cmdline-tools": "commandlinetools-linux-9477386_latest.zip",

--- a/images/ubuntu/toolsets/toolset-2404.json
+++ b/images/ubuntu/toolsets/toolset-2404.json
@@ -63,7 +63,7 @@
     "java": {
         "default": "17",
         "versions": ["11", "17", "21"],
-        "maven": "3.8.8"
+        "maven": "3.8.9"
     },
     "android": {
         "cmdline-tools": "commandlinetools-linux-11076708_latest.zip",

--- a/images/ubuntu/toolsets/toolset-2410.json
+++ b/images/ubuntu/toolsets/toolset-2410.json
@@ -63,7 +63,7 @@
     "java": {
         "default": "17",
         "versions": [ "11", "17", "21"],
-        "maven": "3.8.8"
+        "maven": "3.8.9"
     },
     "android": {
         "cmdline-tools": "commandlinetools-linux-11076708_latest.zip",


### PR DESCRIPTION
Maven 3.8.8 is now unavailable, updating to 3.8.9