### PR TITLE
feat(runner-images): include Rust toolchain in gaplib builds

### DIFF
--- a/scripts/helpers/setup_install.sh
+++ b/scripts/helpers/setup_install.sh
@@ -108,7 +108,7 @@ elif [ "$SETUP" == "complete" ]; then
         "install-pulumi.sh"
         "install-ruby.sh"
         "install-rlang.sh"
-        # "install-rust.sh"
+        "install-rust.sh"
         "install-julia.sh"
         "install-selenium.sh"
         "install-terraform.sh"


### PR DESCRIPTION
Added Rust programming language toolchain to the runner images built with gaplib. This ensures developers can build and test Rust applications directly in CI/CD workflows without requiring manual installation.